### PR TITLE
Add /employees endpoint using Npgsql and PostgreSQL

### DIFF
--- a/HoneyRaesAPI.csproj
+++ b/HoneyRaesAPI.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.15" />
+    <PackageReference Include="Npgsql" Version="8.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 


### PR DESCRIPTION
# Add /employees Endpoint with PostgreSQL Integration

## Summary

Implements a new GET `/employees` endpoint that queries the `Employee` table in the PostgreSQL `HoneyRaes` database using Npgsql.

## Details

- Added `Npgsql` NuGet package (v8.0.1)
- Configured a connection string in `Program.cs`
- Replaced in-memory logic with SQL query using `NpgsqlConnection`, `NpgsqlCommand`, and `NpgsqlDataReader`

## Why

Moves from static data to a real persistent database, allowing the Web API to reflect actual backend state.
